### PR TITLE
Use @2x animated GIF if @3x image is unavailable

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -89,19 +89,23 @@
 + (UIImage *)sd_animatedGIFNamed:(NSString *)name {
     CGFloat scale = [UIScreen mainScreen].scale;
     
-    NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"gif"];
-    
     if (scale > 2.0f) {
-        
-        path = [[NSBundle mainBundle] pathForResource:[name stringByAppendingString:@"@3x"] ofType:@"gif"];
-        
-    } else if (scale > 1.0f) {
-        
-        path = [[NSBundle mainBundle] pathForResource:[name stringByAppendingString:@"@2x"] ofType:@"gif"];
+        NSString *path = [[NSBundle mainBundle] pathForResource:[name stringByAppendingString:@"@3x"] ofType:@"gif"];
+        NSData *data = [NSData dataWithContentsOfFile:path];
+        if (data) {
+            return [UIImage sd_animatedGIFWithData:data];
+        }
+    }
+    if (scale > 1.0f) {
+        NSString *path = [[NSBundle mainBundle] pathForResource:[name stringByAppendingString:@"@2x"] ofType:@"gif"];
+        NSData *data = [NSData dataWithContentsOfFile:path];
+        if (data) {
+            return [UIImage sd_animatedGIFWithData:data];
+        }
     }
     
+    NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"gif"];
     NSData *data = [NSData dataWithContentsOfFile:path];
-    
     if (data) {
         return [UIImage sd_animatedGIFWithData:data];
     }


### PR DESCRIPTION
Hi, @Herb-Sun 

Your @3x animated GIF support is great.
This PR fixes a small problem that SDWebImage cannot find @2x animated GIF if @3x animated GIF image is not available in @3x support device (ie. iPhone 6 Plus and iPhone 6s Plus).
